### PR TITLE
Integrate LangGraph AI detection and spend advisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A comprehensive full-stack application for tracking and managing your subscripti
 - **📧 Gmail Integration** - Connect your Gmail account via OAuth
 - **🤖 Smart Detection** - AI-powered subscription detection from emails
 - **🎯 Pattern Matching** - Support for 30+ popular services (Netflix, Spotify, Amazon, etc.)
+- **🧠 LangGraph Agents** - Use generative AI to review ambiguous emails and recover subscription details
 - **🌍 Multi-language** - English and Chinese service detection
 - **💱 Multi-currency** - Support for USD, EUR, GBP, CNY, and more
 
@@ -29,6 +30,7 @@ A comprehensive full-stack application for tracking and managing your subscripti
 - **👤 User Profiles** - Customizable avatars and preferences
 - **🔐 Secure Authentication** - JWT-based auth with password hashing
 - **📱 Mobile Friendly** - Responsive design for all devices
+- **💬 AI Spend Advisor** - Chatbot powered by LangGraph to suggest how to optimise monthly spend
 
 ## 🏗️ Architecture
 
@@ -131,7 +133,7 @@ docker-compose logs -f
 
 2. **Scan Emails**:
    - Click "Scan for Subscriptions"
-   - Wait for analysis to complete
+   - Wait for analysis to complete (LangGraph agent will review any unrecognized templates)
    - Review detected subscriptions
 
 3. **Import Subscriptions**:
@@ -168,6 +170,13 @@ DB_PORT=5432
 # Application
 NODE_ENV=production
 FRONTEND_URL=http://localhost:5173
+
+# LangGraph AI (optional but recommended for enhanced detection/chat)
+LANGGRAPH_API_URL=https://your-langgraph-deployment
+LANGGRAPH_API_KEY=your_langgraph_api_key
+LANGGRAPH_EMAIL_AGENT_ID=subscription-email-agent
+LANGGRAPH_CHAT_AGENT_ID=spend-coach-agent
+LANGGRAPH_TIMEOUT_MS=15000
 
 # Email notifications (future feature)
 SMTP_HOST=smtp.gmail.com

--- a/SubTrack-backend/src/routes/subsRoute.js
+++ b/SubTrack-backend/src/routes/subsRoute.js
@@ -45,4 +45,7 @@ router.get('/subs/recent', subsController.getRecentSubscriptions);
 // POST /subs/batch - create multiple subscriptions at once
 router.post('/subs/batch', subsController.createBatchSubscriptions);
 
+// POST /subs/ai/chat - converse with AI spend advisor
+router.post('/subs/ai/chat', subsController.chatWithSpendAdvisor);
+
 export default router;

--- a/SubTrack-backend/src/services/aiAgentService.js
+++ b/SubTrack-backend/src/services/aiAgentService.js
@@ -1,0 +1,241 @@
+/**
+ * LangGraph AI integration helper.
+ * This service wraps calls to external LangGraph agents used for
+ * email subscription detection and the spending coach chatbot.
+ */
+class LangGraphAgentService {
+  constructor() {
+    this.baseUrl = process.env.LANGGRAPH_API_URL || '';
+    this.apiKey = process.env.LANGGRAPH_API_KEY || '';
+    this.emailAgentId = process.env.LANGGRAPH_EMAIL_AGENT_ID || '';
+    this.chatAgentId = process.env.LANGGRAPH_CHAT_AGENT_ID || '';
+    this.defaultTimeoutMs = Number(process.env.LANGGRAPH_TIMEOUT_MS || 15000);
+  }
+
+  /**
+   * Whether the LangGraph service has been configured.
+   */
+  isEnabled() {
+    return Boolean(this.baseUrl && this.apiKey);
+  }
+
+  /**
+   * Whether an agent dedicated to email analysis is available.
+   */
+  hasEmailAgent() {
+    return this.isEnabled() && Boolean(this.emailAgentId);
+  }
+
+  /**
+   * Whether the spending coach chatbot agent is configured.
+   */
+  hasChatAgent() {
+    return this.isEnabled() && Boolean(this.chatAgentId);
+  }
+
+  /**
+   * Perform a request to a LangGraph agent and return the JSON payload.
+   *
+   * The service expects a LangSmith-compatible LangGraph deployment
+   * that exposes an `/agents/{id}/invoke` endpoint.
+   */
+  async callAgent(agentId, input, { signal } = {}) {
+    if (!this.isEnabled()) {
+      console.warn('LangGraph agent requested but service is not configured');
+      return null;
+    }
+
+    if (!agentId) {
+      console.warn('LangGraph agent requested without providing an agent ID');
+      return null;
+    }
+
+    const controller = signal ? null : new AbortController();
+    const timeoutMs = this.defaultTimeoutMs;
+
+    if (!signal) {
+      const timeout = setTimeout(() => {
+        controller.abort();
+      }, timeoutMs);
+
+      try {
+        const response = await fetch(`${this.baseUrl}/agents/${agentId}/invoke`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${this.apiKey}`
+          },
+          body: JSON.stringify({ input }),
+          signal: controller.signal
+        });
+
+        if (!response.ok) {
+          const errorBody = await response.text();
+          console.error(`LangGraph agent error (${response.status}):`, errorBody);
+          return null;
+        }
+
+        return await response.json();
+      } catch (error) {
+        if (error.name === 'AbortError') {
+          console.error('LangGraph agent request timed out');
+        } else {
+          console.error('LangGraph agent request failed:', error);
+        }
+        return null;
+      } finally {
+        clearTimeout(timeout);
+      }
+    }
+
+    // If a signal was provided (e.g., upstream timeout control)
+    try {
+      const response = await fetch(`${this.baseUrl}/agents/${agentId}/invoke`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${this.apiKey}`
+        },
+        body: JSON.stringify({ input }),
+        signal
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        console.error(`LangGraph agent error (${response.status}):`, errorBody);
+        return null;
+      }
+
+      return await response.json();
+    } catch (error) {
+      if (error.name === 'AbortError') {
+        console.error('LangGraph agent request aborted by caller');
+      } else {
+        console.error('LangGraph agent request failed:', error);
+      }
+      return null;
+    }
+  }
+
+  /**
+   * Normalise LangGraph output. Some deployments return `{ output: ... }`
+   * while others embed the result in `state.values`.
+   */
+  normalizeAgentPayload(payload) {
+    if (!payload) return null;
+
+    if (payload.output) {
+      return payload.output;
+    }
+
+    if (payload.result) {
+      return payload.result;
+    }
+
+    if (payload.state && typeof payload.state === 'object') {
+      // LangGraph streaming responses tend to surface the final output under `values`
+      const { state } = payload;
+      if (Array.isArray(state.values)) {
+        return state.values[state.values.length - 1];
+      }
+    }
+
+    return payload;
+  }
+
+  /**
+   * Analyse an email to determine if it contains subscription information.
+   */
+  async analyzeEmailForSubscription(emailSummary) {
+    if (!this.hasEmailAgent()) {
+      return null;
+    }
+
+    const payload = {
+      type: 'subscription_email_analysis',
+      email: {
+        id: emailSummary.id,
+        subject: emailSummary.subject,
+        from: emailSummary.from,
+        to: emailSummary.to,
+        snippet: emailSummary.snippet,
+        body: emailSummary.body,
+        received_at: emailSummary.received_at
+      },
+      metadata: {
+        userId: emailSummary.userId,
+        provider: emailSummary.provider
+      }
+    };
+
+    const response = await this.callAgent(this.emailAgentId, payload);
+    const result = this.normalizeAgentPayload(response);
+
+    if (!result) {
+      return null;
+    }
+
+    const normalized = {
+      matched: Boolean(result.subscription_detected ?? result.matched ?? result.is_subscription),
+      confidence: typeof result.confidence === 'number' ? result.confidence : null,
+      data: {
+        service: result.service || result.company || result.subscription?.service || '',
+        amount: result.amount ?? result.subscription?.amount ?? null,
+        currency: result.currency ?? result.subscription?.currency ?? null,
+        cycle: result.billing_cycle ?? result.cycle ?? result.subscription?.billing_cycle ?? null,
+        date: result.next_billing_date ?? result.date ?? result.subscription?.next_billing_date ?? null,
+        reasoning: result.reasoning || result.analysis || result.explanation || '',
+        suggestions: result.suggestions || [],
+        email_id: emailSummary.id,
+        provider: emailSummary.provider
+      }
+    };
+
+    return normalized;
+  }
+
+  /**
+   * Converse with the spending coach chatbot.
+   */
+  async chatWithSpendCoach(input) {
+    if (!this.hasChatAgent()) {
+      return null;
+    }
+
+    const payload = {
+      type: 'spend_coach_chat',
+      user: {
+        id: input.userId,
+        goal: input.goal,
+        locale: input.locale || 'en-US'
+      },
+      message: input.message,
+      conversation: input.history || [],
+      context: {
+        monthly_total: input.monthlyTotal,
+        yearly_total: input.yearlyTotal,
+        subscriptions: input.subscriptions,
+        requested_actions: input.actions || []
+      }
+    };
+
+    const response = await this.callAgent(this.chatAgentId, payload);
+    const result = this.normalizeAgentPayload(response);
+
+    if (!result) {
+      return null;
+    }
+
+    return {
+      message: result.reply || result.message || '',
+      suggestions: result.suggestions || [],
+      actions: result.actions || [],
+      confidence: typeof result.confidence === 'number' ? result.confidence : null,
+      raw: result
+    };
+  }
+}
+
+const langGraphAgentService = new LangGraphAgentService();
+export default langGraphAgentService;
+export { LangGraphAgentService };

--- a/SubTrack-frontend/src/components/ai/AISpendAssistant.jsx
+++ b/SubTrack-frontend/src/components/ai/AISpendAssistant.jsx
@@ -1,0 +1,227 @@
+import { useMemo, useState } from 'react';
+import { Bot, Sparkles, Send, Loader2, Target, Lightbulb } from 'lucide-react';
+import { sendSpendAdvisorMessage } from '../../services/aiAssistant';
+
+const ACTION_OPTIONS = [
+  { id: 'remove', label: 'Remove unused services' },
+  { id: 'downgrade', label: 'Downgrade expensive plans' },
+  { id: 'add', label: 'Add high-value replacements' },
+  { id: 'renegotiate', label: 'Find negotiation opportunities' }
+];
+
+export default function AISpendAssistant({ monthlyTotal = 0 }) {
+  const [goal, setGoal] = useState('Reduce my monthly subscription spending');
+  const [message, setMessage] = useState('Where should I start?');
+  const [selectedActions, setSelectedActions] = useState(['remove', 'downgrade']);
+  const [messages, setMessages] = useState([
+    {
+      role: 'assistant',
+      content: 'Hi! I\'m your LangGraph-powered spend advisor. Tell me what you\'d like to achieve this month and I\'ll help you plan actionable steps.',
+      suggestions: [],
+      confidence: null
+    }
+  ]);
+  const [isSending, setIsSending] = useState(false);
+  const [error, setError] = useState('');
+  const [metadata, setMetadata] = useState(null);
+
+  const toggleAction = (id) => {
+    setSelectedActions(prev =>
+      prev.includes(id)
+        ? prev.filter(action => action !== id)
+        : [...prev, id]
+    );
+  };
+
+  const canSend = message.trim().length > 0 && !isSending;
+
+  const formattedHistory = useMemo(
+    () => messages.map(msg => ({ role: msg.role, content: msg.content })),
+    [messages]
+  );
+
+  const fallbackMonthly = useMemo(() => {
+    const parsed = typeof monthlyTotal === 'number' ? monthlyTotal : parseFloat(monthlyTotal);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }, [monthlyTotal]);
+
+  const displayMonthly = metadata?.monthlyTotal ?? fallbackMonthly;
+  const displayYearly = metadata?.yearlyTotal ?? Number((displayMonthly || 0) * 12);
+  const selectedActionLabels = ACTION_OPTIONS.filter(option => selectedActions.includes(option.id)).map(option => option.label);
+
+  const handleSend = async () => {
+    if (!canSend) return;
+
+    const userMessage = { role: 'user', content: message.trim() };
+    const nextMessages = [...messages, userMessage];
+    setMessages(nextMessages);
+    setMessage('');
+    setIsSending(true);
+    setError('');
+
+    try {
+      const response = await sendSpendAdvisorMessage({
+        message: userMessage.content,
+        goal,
+        actions: selectedActions,
+        history: formattedHistory.concat(userMessage),
+        locale: navigator.language
+      });
+
+      setMetadata(response.metadata || null);
+
+      setMessages(prev => [
+        ...prev,
+        {
+          role: 'assistant',
+          content: response.reply || 'I\'m still thinking about that... try asking again in a moment.',
+          suggestions: response.suggestions || [],
+          confidence: response.confidence || null,
+          actions: response.actions || []
+        }
+      ]);
+    } catch (err) {
+      console.error('Spend advisor error:', err);
+      setError(err.response?.data?.message || 'Failed to contact the AI assistant. Please try again later.');
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  return (
+    <div className="bg-base-100 shadow rounded-lg p-6 space-y-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-full bg-primary/10 text-primary">
+            <Bot size={22} />
+          </div>
+          <div>
+            <h2 className="text-xl font-semibold">AI Spend Advisor</h2>
+            <p className="text-sm text-base-content/60">
+              Powered by LangGraph to analyse subscriptions and optimise your monthly spending.
+            </p>
+          </div>
+        </div>
+        <div className="flex gap-3">
+          <div className="badge badge-outline">
+            Monthly: ${displayMonthly.toFixed(2)}
+          </div>
+          <div className="badge badge-outline">
+            Yearly: ${displayYearly.toFixed(2)}
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <label className="form-control w-full">
+          <span className="label-text font-medium flex items-center gap-2">
+            <Target size={16} /> Monthly goal
+          </span>
+          <input
+            type="text"
+            className="input input-bordered"
+            value={goal}
+            onChange={e => setGoal(e.target.value)}
+            placeholder="Set a focus for this month"
+          />
+        </label>
+        <div>
+          <span className="label-text font-medium flex items-center gap-2 mb-2">
+            <Lightbulb size={16} /> Focus areas
+          </span>
+          <div className="flex flex-wrap gap-2">
+            {ACTION_OPTIONS.map(option => (
+              <button
+                key={option.id}
+                type="button"
+                onClick={() => toggleAction(option.id)}
+                className={`btn btn-sm ${selectedActions.includes(option.id) ? 'btn-primary' : 'btn-outline'}`}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-base-200 rounded-lg p-4 h-72 overflow-y-auto space-y-4">
+        {messages.map((msg, index) => (
+          <div
+            key={index}
+            className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
+          >
+            <div
+              className={`max-w-[80%] rounded-lg px-4 py-3 text-sm shadow ${
+                msg.role === 'user'
+                  ? 'bg-primary text-primary-content'
+                  : 'bg-base-100 text-base-content'
+              }`}
+            >
+              <p className="whitespace-pre-line">{msg.content}</p>
+              {msg.confidence !== null && (
+                <div className="mt-2 text-xs opacity-70">
+                  Confidence: {(msg.confidence * 100).toFixed(0)}%
+                </div>
+              )}
+              {msg.suggestions && msg.suggestions.length > 0 && (
+                <div className="mt-3 space-y-1">
+                  <p className="text-xs font-semibold flex items-center gap-1">
+                    <Sparkles size={14} /> Suggestions
+                  </p>
+                  <ul className="text-xs space-y-1 list-disc list-inside">
+                    {msg.suggestions.map((suggestion, suggestionIndex) => (
+                      <li key={suggestionIndex}>{suggestion}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+        {messages.length === 0 && (
+          <div className="text-center text-sm text-base-content/60">
+            Ask the assistant how to optimise your subscriptions this month.
+          </div>
+        )}
+      </div>
+
+      {error && (
+        <div className="alert alert-error">
+          <span>{error}</span>
+        </div>
+      )}
+
+      <div className="space-y-3">
+        <textarea
+          className="textarea textarea-bordered w-full"
+          rows={3}
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder="Ask for advice, e.g. ‘Help me cut $50 from my recurring spend.’"
+        />
+        <div className="flex items-center justify-between gap-3">
+          <div className="text-xs text-base-content/60">
+            Selected focus: {selectedActionLabels.length > 0 ? selectedActionLabels.join(', ') : 'none'}
+          </div>
+          <button
+            className="btn btn-primary"
+            onClick={handleSend}
+            disabled={!canSend}
+          >
+            {isSending ? (
+              <>
+                <Loader2 className="w-4 h-4 animate-spin" />
+                Thinking...
+              </>
+            ) : (
+              <>
+                <Send className="w-4 h-4" />
+                Ask Advisor
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/SubTrack-frontend/src/components/email/SubscriptionMatcher.jsx
+++ b/SubTrack-frontend/src/components/email/SubscriptionMatcher.jsx
@@ -290,6 +290,9 @@ export default function SubscriptionMatcher({ newSubscriptions, onComplete }) {
                       ) : (
                         <div className="flex items-center gap-2">
                           <span className="font-medium">{subscription.company}</span>
+                          {subscription.detected_via_ai && (
+                            <span className="badge badge-info badge-sm">AI</span>
+                          )}
                           <button
                             className="btn btn-ghost btn-xs"
                             onClick={() => setEditingIndex(index)}
@@ -301,6 +304,11 @@ export default function SubscriptionMatcher({ newSubscriptions, onComplete }) {
                       {subscription.notes && (
                         <div className="text-xs text-gray-500 mt-1">
                           {subscription.notes}
+                        </div>
+                      )}
+                      {subscription.source && (
+                        <div className="text-[10px] uppercase tracking-wide text-gray-400 mt-1">
+                          Source: {subscription.source}
                         </div>
                       )}
                     </div>

--- a/SubTrack-frontend/src/pages/DashboardPage.jsx
+++ b/SubTrack-frontend/src/pages/DashboardPage.jsx
@@ -5,6 +5,7 @@ import { CalendarDays, TrendingUp, ArrowRight, BarChart3, PieChart } from 'lucid
 import api from '../services/api';
 import CategoryChart from '../components/dashboard/CategoryChart';
 import CategorySummary from '../components/dashboard/CategorySummary';
+import AISpendAssistant from '../components/ai/AISpendAssistant';
 
 export default function DashboardPage() {
   const { data: subscriptions, isLoading, error } = useQuery({
@@ -241,6 +242,9 @@ export default function DashboardPage() {
           </div>
         )}
       </div>
+      
+      {/* AI Spend Advisor */}
+      <AISpendAssistant monthlyTotal={stats.totalMonthly} />
     </div>
   );
 }

--- a/SubTrack-frontend/src/services/aiAssistant.js
+++ b/SubTrack-frontend/src/services/aiAssistant.js
@@ -1,0 +1,16 @@
+import api from './api';
+
+/**
+ * Send a message to the LangGraph-powered spending advisor.
+ */
+export const sendSpendAdvisorMessage = async ({ message, goal, actions, history, locale }) => {
+  const response = await api.post('/subs/ai/chat', {
+    message,
+    goal,
+    actions,
+    history,
+    locale
+  });
+
+  return response.data;
+};


### PR DESCRIPTION
## Summary
- add a LangGraph agent service to drive subscription email analysis and the new spending advisor
- fall back to the agent when scanning mail, expose a spend-coach chat endpoint, and surface AI detections in review flows
- ship a dashboard AI chat experience plus documentation for configuring the agents

## Testing
- npm run lint *(fails: existing lint errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68cdbfe5655c8331969536f6a0ece475