### PR TITLE
Add email-based registration and password reset flows

### DIFF
--- a/SubTrack-backend/package.json
+++ b/SubTrack-backend/package.json
@@ -19,6 +19,7 @@
     "google-auth-library": "^9.15.1",
     "googleapis": "^148.0.0",
     "jsonwebtoken": "^9.0.2",
+    "nodemailer": "^6.9.16",
     "multer": "^1.4.5-lts.2",
     "node-cron": "^4.1.0",
     "pg": "^8.15.6"

--- a/SubTrack-backend/src/routes/authRoute.js
+++ b/SubTrack-backend/src/routes/authRoute.js
@@ -12,6 +12,12 @@ router.post('/login', authController.login);
 // POST /logout - log out a user
 router.post('/logout', authController.logout);
 
+// POST /forgot-password - start reset flow
+router.post('/forgot-password', authController.requestPasswordReset);
+
+// POST /reset-password - finish reset flow
+router.post('/reset-password', authController.resetPassword);
+
 // GET /verify - verify if current token is valid
 router.get('/verify', authController.verifyToken);
 

--- a/SubTrack-backend/src/services/notificationService.js
+++ b/SubTrack-backend/src/services/notificationService.js
@@ -1,0 +1,108 @@
+// Centralized transactional email helpers
+// File: SubTrack-backend/src/services/notificationService.js
+
+import { sendEmail } from '../utils/emailClient.js';
+
+const appUrl = process.env.APP_URL || 'http://localhost:5173';
+
+export const sendWelcomeEmail = async (user) => {
+  if (!user?.email) {
+    return;
+  }
+
+  const subject = 'Welcome to SubTrack – your subscription co-pilot';
+  const html = `
+    <h1>Welcome aboard, ${user.username || 'there'}!</h1>
+    <p>Thanks for creating a SubTrack account. You're moments away from gaining complete visibility of your recurring costs.</p>
+    <p>You can log in anytime at <a href="${appUrl}">${appUrl}</a>.</p>
+    <p>Happy tracking!<br/>The SubTrack Team</p>
+  `;
+
+  const text = `Welcome aboard, ${user.username || 'there'}!
+
+Thanks for creating a SubTrack account. You're moments away from gaining complete visibility of your recurring costs.
+
+You can log in anytime at ${appUrl}.
+
+Happy tracking!
+The SubTrack Team`;
+
+  await sendEmail({
+    to: user.email,
+    subject,
+    html,
+    text
+  });
+};
+
+export const sendPasswordResetEmail = async (user, token) => {
+  if (!user?.email || !token) {
+    return;
+  }
+
+  const resetLink = `${appUrl}/reset-password?token=${encodeURIComponent(token)}`;
+  const subject = 'Reset your SubTrack password';
+  const html = `
+    <h1>Password reset requested</h1>
+    <p>Hello ${user.username || 'there'},</p>
+    <p>We received a request to reset the password for your SubTrack account. You can set a new password by clicking the button below.</p>
+    <p><a href="${resetLink}" style="display:inline-block;padding:12px 20px;background-color:#6366f1;color:#ffffff;text-decoration:none;border-radius:6px;">Choose a new password</a></p>
+    <p>If you didn't request this change you can safely ignore this email. The link will expire in 1 hour.</p>
+    <p>Stay secure,<br/>The SubTrack Team</p>
+  `;
+
+  const text = `Hello ${user.username || 'there'},
+
+We received a request to reset the password for your SubTrack account. Use the link below to choose a new password:
+${resetLink}
+
+If you didn't request this change you can safely ignore this email. The link will expire in 1 hour.
+
+Stay secure,
+The SubTrack Team`;
+
+  await sendEmail({
+    to: user.email,
+    subject,
+    html,
+    text
+  });
+};
+
+export const sendPasswordChangedEmail = async (user) => {
+  if (!user?.email) {
+    return;
+  }
+
+  const subject = 'Your SubTrack password was changed';
+  const html = `
+    <h1>Password updated successfully</h1>
+    <p>Hi ${user.username || 'there'},</p>
+    <p>This is a confirmation that the password for your SubTrack account was changed.</p>
+    <p>If you didn't perform this action, please reset your password immediately from the following link:</p>
+    <p><a href="${appUrl}/forgot-password">Reset your password</a></p>
+    <p>Keep tracking with confidence!<br/>The SubTrack Team</p>
+  `;
+
+  const text = `Hi ${user.username || 'there'},
+
+This is a confirmation that the password for your SubTrack account was changed.
+
+If you didn't perform this action, please reset your password immediately at ${appUrl}/forgot-password.
+
+Keep tracking with confidence!
+The SubTrack Team`;
+
+  await sendEmail({
+    to: user.email,
+    subject,
+    html,
+    text
+  });
+};
+
+export default {
+  sendWelcomeEmail,
+  sendPasswordResetEmail,
+  sendPasswordChangedEmail
+};

--- a/SubTrack-backend/src/utils/emailClient.js
+++ b/SubTrack-backend/src/utils/emailClient.js
@@ -1,0 +1,71 @@
+// Utility to send transactional emails with graceful fallbacks
+// File: SubTrack-backend/src/utils/emailClient.js
+
+import process from 'process';
+
+let transporterPromise = null;
+
+const createTransporter = async () => {
+  if (transporterPromise) {
+    return transporterPromise;
+  }
+
+  transporterPromise = (async () => {
+    try {
+      const nodemailerModule = await import('nodemailer');
+      const nodemailer = nodemailerModule.default || nodemailerModule;
+
+      if (process.env.SMTP_HOST) {
+        return nodemailer.createTransport({
+          host: process.env.SMTP_HOST,
+          port: parseInt(process.env.SMTP_PORT || '587', 10),
+          secure: process.env.SMTP_SECURE === 'true',
+          auth: process.env.SMTP_USER
+            ? {
+                user: process.env.SMTP_USER,
+                pass: process.env.SMTP_PASS
+              }
+            : undefined
+        });
+      }
+
+      console.warn('[email] SMTP configuration missing. Falling back to JSON transport.');
+      return nodemailer.createTransport({ jsonTransport: true });
+    } catch (error) {
+      console.warn('[email] Nodemailer unavailable. Emails will be logged instead.', error.message);
+      return {
+        sendMail: async (mailOptions) => {
+          console.log('[email] Simulated send:', JSON.stringify(mailOptions, null, 2));
+          return { messageId: 'simulated', response: 'Email logged to console' };
+        }
+      };
+    }
+  })();
+
+  return transporterPromise;
+};
+
+export const sendEmail = async ({ to, subject, html, text }) => {
+  const transporter = await createTransporter();
+  const fromAddress = process.env.EMAIL_FROM || 'SubTrack <no-reply@subtrack.app>';
+
+  const mailOptions = {
+    from: fromAddress,
+    to,
+    subject,
+    text,
+    html
+  };
+
+  const info = await transporter.sendMail(mailOptions);
+
+  if (process.env.SMTP_HOST) {
+    console.log(`[email] Message queued for ${to} with id ${info.messageId}`);
+  }
+
+  return info;
+};
+
+export default {
+  sendEmail
+};

--- a/SubTrack-frontend/src/App.jsx
+++ b/SubTrack-frontend/src/App.jsx
@@ -14,6 +14,8 @@ import SubscriptionsPage from './pages/SubscriptionsPage';
 import SettingsPage from './pages/SettingsPage';
 import EmailIntegrationPage from './pages/EmailIntegrationPage';
 import EmailCallbackPage from './pages/EmailCallbackPage';
+import ForgotPasswordPage from './pages/ForgotPasswordPage';
+import ResetPasswordPage from './pages/ResetPasswordPage';
 
 // Import layout
 import MainLayout from './components/layout/MainLayout';
@@ -91,6 +93,16 @@ function App() {
             <Route path="/register" element={
               <AuthLayout>
                 <RegisterPage />
+              </AuthLayout>
+            } />
+            <Route path="/forgot-password" element={
+              <AuthLayout>
+                <ForgotPasswordPage />
+              </AuthLayout>
+            } />
+            <Route path="/reset-password" element={
+              <AuthLayout>
+                <ResetPasswordPage />
               </AuthLayout>
             } />
 

--- a/SubTrack-frontend/src/pages/ForgotPasswordPage.jsx
+++ b/SubTrack-frontend/src/pages/ForgotPasswordPage.jsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { requestPasswordReset } from '../services/authService';
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState({ type: '', message: '' });
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setStatus({ type: '', message: '' });
+
+    if (!email) {
+      setStatus({ type: 'error', message: 'Please enter the email associated with your account.' });
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+      await requestPasswordReset(email);
+      setStatus({
+        type: 'success',
+        message: 'If an account exists for that email, password reset instructions have been sent.'
+      });
+    } catch (error) {
+      console.error('Failed to request password reset:', error);
+      setStatus({
+        type: 'error',
+        message: error.response?.data?.message || 'We were unable to process your request. Please try again later.'
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center px-6 py-8 mx-auto w-full max-w-md">
+      <div className="w-full bg-white rounded-lg shadow-md p-6">
+        <div className="text-center mb-6">
+          <h1 className="text-2xl font-bold text-gray-900">Forgot your password?</h1>
+          <p className="mt-2 text-sm text-gray-600">
+            Enter your email address and we'll send you a link to reset your password.
+          </p>
+        </div>
+
+        {status.message && (
+          <div className={`alert ${status.type === 'success' ? 'alert-success' : 'alert-error'} mb-4`}>
+            <span>{status.message}</span>
+          </div>
+        )}
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-gray-700">Email address</label>
+            <input
+              type="email"
+              id="email"
+              className="input input-bordered w-full mt-1"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              required
+              placeholder="you@example.com"
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="btn btn-primary w-full"
+            disabled={submitting}
+          >
+            {submitting ? <span className="loading loading-spinner loading-sm"></span> : 'Send reset instructions'}
+          </button>
+        </form>
+
+        <div className="text-sm text-center text-gray-600 mt-6">
+          Remembered your password?{' '}
+          <Link to="/login" className="text-primary hover:underline">Back to sign in</Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/SubTrack-frontend/src/pages/LoginPage.jsx
+++ b/SubTrack-frontend/src/pages/LoginPage.jsx
@@ -77,7 +77,7 @@ export default function LoginPage() {
               <input id="remember-me" type="checkbox" className="checkbox checkbox-primary" />
               <label htmlFor="remember-me" className="ml-2 text-sm text-gray-600">Remember me</label>
             </div>
-            <a href="#" className="text-sm text-primary hover:underline">Forgot password?</a>
+            <Link to="/forgot-password" className="text-sm text-primary hover:underline">Forgot password?</Link>
           </div>
           
           <button 

--- a/SubTrack-frontend/src/pages/ResetPasswordPage.jsx
+++ b/SubTrack-frontend/src/pages/ResetPasswordPage.jsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from 'react';
+import { Link, useSearchParams, useNavigate } from 'react-router-dom';
+import { resetPassword } from '../services/authService';
+
+export default function ResetPasswordPage() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const [formState, setFormState] = useState({ password: '', confirmPassword: '' });
+  const [status, setStatus] = useState({ type: '', message: '' });
+  const [token, setToken] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    const tokenValue = searchParams.get('token');
+    if (tokenValue) {
+      setToken(tokenValue);
+    } else {
+      setStatus({ type: 'error', message: 'Reset link is invalid or has already been used.' });
+    }
+  }, [searchParams]);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setFormState((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setStatus({ type: '', message: '' });
+
+    if (!token) {
+      setStatus({ type: 'error', message: 'Reset link is invalid or has expired.' });
+      return;
+    }
+
+    if (!formState.password || formState.password.length < 6) {
+      setStatus({ type: 'error', message: 'Password must be at least 6 characters long.' });
+      return;
+    }
+
+    if (formState.password !== formState.confirmPassword) {
+      setStatus({ type: 'error', message: 'Passwords do not match. Please try again.' });
+      return;
+    }
+
+    try {
+      setSubmitting(true);
+      await resetPassword({ token, password: formState.password });
+      setStatus({ type: 'success', message: 'Your password has been updated. You can now sign in with the new password.' });
+
+      setTimeout(() => {
+        navigate('/login');
+      }, 2500);
+    } catch (error) {
+      console.error('Failed to reset password:', error);
+      setStatus({
+        type: 'error',
+        message: error.response?.data?.message || 'Unable to reset password. Your link may have expired.'
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center px-6 py-8 mx-auto w-full max-w-md">
+      <div className="w-full bg-white rounded-lg shadow-md p-6">
+        <div className="text-center mb-6">
+          <h1 className="text-2xl font-bold text-gray-900">Choose a new password</h1>
+          <p className="mt-2 text-sm text-gray-600">
+            Your new password must be at least 6 characters and should be something you haven't used before.
+          </p>
+        </div>
+
+        {status.message && (
+          <div className={`alert ${status.type === 'success' ? 'alert-success' : 'alert-error'} mb-4`}>
+            <span>{status.message}</span>
+          </div>
+        )}
+
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-gray-700">New password</label>
+            <input
+              type="password"
+              id="password"
+              name="password"
+              className="input input-bordered w-full mt-1"
+              value={formState.password}
+              onChange={handleChange}
+              required
+              minLength={6}
+            />
+          </div>
+
+          <div>
+            <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-700">Confirm password</label>
+            <input
+              type="password"
+              id="confirmPassword"
+              name="confirmPassword"
+              className="input input-bordered w-full mt-1"
+              value={formState.confirmPassword}
+              onChange={handleChange}
+              required
+              minLength={6}
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="btn btn-primary w-full"
+            disabled={submitting || !token}
+          >
+            {submitting ? <span className="loading loading-spinner loading-sm"></span> : 'Update password'}
+          </button>
+        </form>
+
+        <div className="text-sm text-center text-gray-600 mt-6">
+          Not working?{' '}
+          <Link to="/forgot-password" className="text-primary hover:underline">Request a new reset link</Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/SubTrack-frontend/src/services/authService.js
+++ b/SubTrack-frontend/src/services/authService.js
@@ -1,0 +1,16 @@
+import api from './api';
+
+export const requestPasswordReset = async (email) => {
+  const response = await api.post('/auth/forgot-password', { email });
+  return response.data;
+};
+
+export const resetPassword = async ({ token, password }) => {
+  const response = await api.post('/auth/reset-password', { token, password });
+  return response.data;
+};
+
+export default {
+  requestPasswordReset,
+  resetPassword
+};

--- a/database/init.sql
+++ b/database/init.sql
@@ -35,6 +35,17 @@ CREATE TABLE IF NOT EXISTS auth_tokens (
     created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Password reset tokens table - stores password reset requests
+CREATE TABLE IF NOT EXISTS password_reset_tokens (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+    token_hash CHARACTER VARYING(255) NOT NULL,
+    expires_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    used BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    used_at TIMESTAMP WITHOUT TIME ZONE
+);
+
 -- Subscriptions table - stores user subscription data
 CREATE TABLE IF NOT EXISTS subscriptions (
     id SERIAL PRIMARY KEY,
@@ -120,6 +131,8 @@ CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
 CREATE INDEX IF NOT EXISTS idx_users_username ON users(username);
 CREATE INDEX IF NOT EXISTS idx_auth_tokens_user_id ON auth_tokens(user_id);
 CREATE INDEX IF NOT EXISTS idx_auth_tokens_token ON auth_tokens(token);
+CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_user_id ON password_reset_tokens(user_id);
+CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_token_hash ON password_reset_tokens(token_hash);
 CREATE INDEX IF NOT EXISTS idx_subscriptions_user_id ON subscriptions(user_id);
 CREATE INDEX IF NOT EXISTS idx_subscriptions_next_billing_date ON subscriptions(next_billing_date);
 CREATE INDEX IF NOT EXISTS idx_email_connections_user_id ON email_connections(user_id);


### PR DESCRIPTION
## Summary
- add a reusable email client with graceful fallbacks and notification helpers for welcome, reset, and confirmation messages
- extend authentication services, controllers, and routes with password reset token storage and outbound email delivery
- expose forgot/reset password pages on the frontend with supporting auth service helpers and navigation tweaks
- ensure password changes invalidate existing sessions and notify the user

## Testing
- `npm run build` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68cdc911f2c483319703d28af2cf52a5