### PR TITLE
Add LangGraph env variables to backend Docker configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ LANGGRAPH_EMAIL_AGENT_ID=subscription-email-agent
 LANGGRAPH_CHAT_AGENT_ID=spend-coach-agent
 LANGGRAPH_TIMEOUT_MS=15000
 
+> **Docker deployments:** Ensure each `LANGGRAPH_*` variable is present in your `.env` file so `docker-compose` can forward them to the backend container.
+
 # Email notifications (future feature)
 SMTP_HOST=smtp.gmail.com
 SMTP_PORT=587

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,13 +51,20 @@ services:
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
       GOOGLE_REDIRECT_URI: ${GOOGLE_REDIRECT_URI:-http://localhost:5173/email/callback}
-      
+
       # Email configuration (optional)
       EMAIL_FROM: ${EMAIL_FROM}
       SMTP_HOST: ${SMTP_HOST}
       SMTP_PORT: ${SMTP_PORT}
       SMTP_USER: ${SMTP_USER}
       SMTP_PASSWORD: ${SMTP_PASSWORD}
+
+      # LangGraph AI assistant configuration
+      LANGGRAPH_API_URL: ${LANGGRAPH_API_URL}
+      LANGGRAPH_API_KEY: ${LANGGRAPH_API_KEY}
+      LANGGRAPH_EMAIL_AGENT_ID: ${LANGGRAPH_EMAIL_AGENT_ID}
+      LANGGRAPH_CHAT_AGENT_ID: ${LANGGRAPH_CHAT_AGENT_ID}
+      LANGGRAPH_TIMEOUT_MS: ${LANGGRAPH_TIMEOUT_MS}
     ports:
       - "${BACKEND_PORT:-3000}:3000"
     networks:


### PR DESCRIPTION
## Summary
- expose all LANGGRAPH_* environment variables in the backend service of docker-compose so they inherit from the host .env
- document that Docker deployments must define the LangGraph variables for the assistant features to work

## Testing
- `docker-compose up -d --build` *(fails: command not found: docker-compose)*

------
https://chatgpt.com/codex/tasks/task_e_68cdeac4f414833189500447ad472b1c