### PR TITLE
Normalize spend advisor actions

### DIFF
--- a/SubTrack-backend/package.json
+++ b/SubTrack-backend/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",

--- a/SubTrack-backend/src/controllers/subsController.js
+++ b/SubTrack-backend/src/controllers/subsController.js
@@ -4,6 +4,7 @@
 import * as subsService from '../services/subsServices.js';
 import { query } from '../db.js';
 import langGraphAgentService from '../services/aiAgentService.js';
+import { normalizeChatActions } from '../utils/chatActions.js';
 
 /**
  * Get all subscriptions for the authenticated user with auto-update
@@ -377,6 +378,8 @@ export const chatWithSpendAdvisor = async (req, res) => {
     const userId = req.user.id;
     const { message, goal, actions, history, locale } = req.body;
 
+    const normalizedActions = normalizeChatActions(actions);
+
     if (!message || typeof message !== 'string') {
       return res.status(400).json({ message: 'Message is required' });
     }
@@ -440,7 +443,7 @@ export const chatWithSpendAdvisor = async (req, res) => {
       userId,
       goal,
       message,
-      actions,
+      actions: normalizedActions,
       history,
       locale,
       subscriptions: normalizedSubs,

--- a/SubTrack-backend/src/utils/chatActions.js
+++ b/SubTrack-backend/src/utils/chatActions.js
@@ -1,0 +1,44 @@
+const ACTION_ALIAS_MAP = new Map([
+  ['create', 'create'],
+  ['add', 'create'],
+  ['new', 'create'],
+  ['start', 'create'],
+  ['subscribe', 'create'],
+  ['sign up', 'create'],
+  ['sign-up', 'create'],
+  ['signup', 'create'],
+  ['update', 'update'],
+  ['edit', 'update'],
+  ['change', 'update'],
+  ['modify', 'update'],
+  ['adjust', 'update'],
+  ['delete', 'delete'],
+  ['remove', 'delete'],
+  ['cancel', 'delete'],
+  ['stop', 'delete'],
+  ['terminate', 'delete'],
+  ['end', 'delete'],
+  ['unsubscribe', 'delete']
+]);
+
+export const normalizeChatActions = actionsInput => {
+  if (!Array.isArray(actionsInput)) {
+    return [];
+  }
+
+  const normalized = new Set();
+
+  for (const rawAction of actionsInput) {
+    if (typeof rawAction !== 'string') {
+      continue;
+    }
+
+    const canonical = ACTION_ALIAS_MAP.get(rawAction.trim().toLowerCase());
+
+    if (canonical) {
+      normalized.add(canonical);
+    }
+  }
+
+  return Array.from(normalized);
+};

--- a/SubTrack-backend/tests/normalizeChatActions.test.js
+++ b/SubTrack-backend/tests/normalizeChatActions.test.js
@@ -1,0 +1,14 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeChatActions } from '../src/utils/chatActions.js';
+
+describe('normalizeChatActions', () => {
+  it('normalizes known aliases to canonical create action', () => {
+    assert.deepStrictEqual(normalizeChatActions(['add']), ['create']);
+  });
+
+  it('deduplicates and filters unknown entries', () => {
+    const result = normalizeChatActions(['Add', 'create', 'REMOVE', 'unknown', 'Edit', '  sign up  ']);
+    assert.deepStrictEqual(result, ['create', 'delete', 'update']);
+  });
+});


### PR DESCRIPTION
## Summary
- normalize requested actions before invoking the spend coach agent
- extract action alias handling into a shared utility with coverage for common synonyms
- configure the backend test script to run the new node-based tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdeac60b108331a88d62e4d8e43c50