### PR TITLE
Add LangGraph integration placeholders to env template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,17 @@ SMTP_HOST=smtp.gmail.com
 SMTP_PORT=587
 SMTP_USER=your_smtp_username
 SMTP_PASSWORD=your_smtp_password
+
+# =============================================================================
+# LANGGRAPH AI INTEGRATION
+# =============================================================================
+# Base URL where LangGraph API requests are sent
+LANGGRAPH_API_URL=https://api.langgraph.example.com
+# API key used to authenticate with LangGraph services
+LANGGRAPH_API_KEY=your_langgraph_api_key
+# Agent ID used for LangGraph-powered email generation workflows
+LANGGRAPH_EMAIL_AGENT_ID=langgraph_email_agent_id
+# Agent ID used for LangGraph-powered chat interactions
+LANGGRAPH_CHAT_AGENT_ID=langgraph_chat_agent_id
+# Request timeout (in milliseconds) for LangGraph API calls
+LANGGRAPH_TIMEOUT_MS=10000


### PR DESCRIPTION
## Summary
- add a LangGraph AI integration section to the environment template with placeholder variables and guidance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdeac657b08331b9f9b47e83a328d1