### PR TITLE
Remove duplicate profile route registration

### DIFF
--- a/SubTrack-backend/src/routes/userRoute.js
+++ b/SubTrack-backend/src/routes/userRoute.js
@@ -46,9 +46,6 @@ router.get('/me', userController.getCurrentUser);
 // PUT /profile - update profile (with file upload)
 router.put('/profile', upload.single('profile_image'), userController.updateProfile);
 
-// Route configuration
-router.put('/profile', authenticateToken, upload.single('profile_image'), userController.updateProfile);
-
 // GET /preferences - get user preferences
 router.get('/preferences', userController.getUserPreferences);
 


### PR DESCRIPTION
## Summary
- remove the redundant `/profile` route registration so the existing handler uses the shared authentication middleware

## Testing
- node --test tests/avatar-smoke.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cdeff90e0c8331809a827524e55304