### PR TITLE
Configure frontend API base URL via env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,8 @@ pnpm-debug.log*
 
 # Ignore all .env files except examples
 !.env.example
+# Frontend defaults for local development
+!SubTrack-frontend/.env.development
 
 # Prisma (if using)
 prisma/.env

--- a/SubTrack-frontend/.env.development
+++ b/SubTrack-frontend/.env.development
@@ -1,0 +1,3 @@
+VITE_API_URL=http://localhost:3000/api
+# Enable to log API requests and responses in the browser console
+VITE_API_DEBUG=false

--- a/SubTrack-frontend/README.md
+++ b/SubTrack-frontend/README.md
@@ -1,12 +1,48 @@
-# React + Vite
+# SubTrack Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This package contains the React application served by Vite for the SubTrack project.
 
-Currently, two official plugins are available:
+## Prerequisites
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- Node.js 20+
+- npm 10+
 
-## Expanding the ESLint configuration
+## Installation
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+```bash
+npm install
+```
+
+## Environment configuration
+
+Vite reads environment variables from `.env` files at the project root. The repo provides a default development configuration in [`.env.development`](./.env.development) that points the frontend to the local API gateway:
+
+```
+VITE_API_URL=http://localhost:3000/api
+VITE_API_DEBUG=false
+```
+
+To customize the values, create a `.env.local` (or another [Vite environment file](https://vitejs.dev/guide/env-and-mode.html#env-files)) with overrides. The available variables are:
+
+- `VITE_API_URL`: Base URL for API requests. Defaults to `/api` when unset so the frontend can proxy requests through the same origin.
+- `VITE_API_DEBUG`: Set to `true` to log axios request/response information in the browser console. Defaults to `false`.
+
+## Development
+
+```bash
+npm run dev
+```
+
+The command uses the values from `.env.development` by default, so requests are sent to `http://localhost:3000/api`.
+
+## Linting
+
+```bash
+npm run lint
+```
+
+## Production build
+
+```bash
+npm run build
+```


### PR DESCRIPTION
## Summary
- read the axios API base URL from `VITE_API_URL` with a `/api` fallback
- gate request/response logging behind a `VITE_API_DEBUG` flag
- document the new environment variables and commit a development `.env`

## Testing
- npm run lint *(fails: existing lint errors in unrelated components)*

------
https://chatgpt.com/codex/tasks/task_e_68cdeffa12ec8331a9b56c10b333415c