### PR TITLE
docs: clarify local development options

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,14 +210,24 @@ The application includes templates for detecting subscriptions from these servic
 ## 🛠️ Development
 
 ### Local Development Setup
+
+You can run the entire stack with Docker Compose:
+
+```bash
+# Full stack (frontend, backend, database)
+docker-compose up --build
+```
+
+Or run the services manually for iterative development:
+
 ```bash
 # Backend development
 cd SubTrack-backend
 npm install
-npm run dev
+npx nodemon src/index.js
 
 # Frontend development
-cd SubTrack-frontend
+cd ../SubTrack-frontend
 npm install
 npm run dev
 


### PR DESCRIPTION
## Summary
- replace the README backend development command with the actual runnable nodemon invocation
- ensure backend documentation references now point to the same corrected command
- document the docker-compose workflow alongside the manual setup for local development

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d1d132967c83318589951c2aebca6d